### PR TITLE
Merging header values from invoke_api call

### DIFF
--- a/lib/lapiz.rb
+++ b/lib/lapiz.rb
@@ -75,6 +75,8 @@ module Lapiz
             path = path.gsub( "{#{arg_name}}", arg_value.to_s )
           end
 
+          @_params[:headers] = (@_params[:headers] || {}).merge(args[:headers] || {})
+
           body = args[:body] || @_params[:body]
 
           expect {

--- a/lib/lapiz/version.rb
+++ b/lib/lapiz/version.rb
@@ -1,3 +1,3 @@
 module Lapiz
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end


### PR DESCRIPTION
Allowing calls to `invoke_api` with header values. This allows the header to have dynamic values from `let` statements.

e.g.
```ruby
invoke_api(status: 'pending', headers: {
      "X-USER-ID"   => influencer.id,
      "X-USER-TYPE" => 'Influencer',
    })
```